### PR TITLE
Group blog posts by year and remove date

### DIFF
--- a/themes/superluminar/layouts/post/list.html
+++ b/themes/superluminar/layouts/post/list.html
@@ -6,15 +6,13 @@
           </header>
           {{ .Content }}
         </article>
-        <table class="mb2">
-              {{ $paginator := .Paginate (where .Data.Pages "Type" "post") 50 }}
-              {{ range $paginator.Pages }}
-              <tr>
-                <td class="bold">{{ .Date.Format "2006-01-02" }}</td>
-                <td><a href="{{ .Permalink }}">{{ .Title }}</a></td>
-              </tr>
+              {{ range .Data.Pages.GroupByDate "2006" }}
+              <h3>{{ .Key }}</h3>
+              <ul class="list-reset">
+                {{ range .Pages }}
+                <li><a href="{{ .Permalink }}" class="btn pl0">{{ .Title }}</a></li>
+                {{ end }}
+              </ul>
               {{ end }}
-              <!-- {{ partial "pagination.html" . }} -->
-        </table>
 	</main>
 {{ partial "footer.html" . }}


### PR DESCRIPTION
This groups blog posts by year and removes the exact date.
I believe this makes the blog page more readable.

<img width="1060" alt="screen shot 2018-05-30 at 23 50 43" src="https://user-images.githubusercontent.com/49786/40749433-53e5c80a-6464-11e8-9268-710d94b3e869.png">
