### PR TITLE
don't track local dev traffic in Google Analytics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ develop: hugo
 	./hugo serve -D
 
 public: hugo
-	./hugo
+	HUGO_ENV=prod ./hugo
 
 install: hugo
 

--- a/themes/superluminar/layouts/partials/header.html
+++ b/themes/superluminar/layouts/partials/header.html
@@ -26,7 +26,7 @@
         </style>
 
 </head>
-{{ if .Site.Params.gaTrackingId -}}
+{{ if and ( eq (getenv "HUGO_ENV") "prod" ) ( .Site.Params.gaTrackingId ) -}}
 <!-- Global Site Tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Params.gaTrackingId }}"></script>
 <script>


### PR DESCRIPTION
by only including GA stuff when building the website, not in local preview
mode